### PR TITLE
Fix issue where COLIN and LEAR records could be re-queued.

### DIFF
--- a/openshift/manage
+++ b/openshift/manage
@@ -636,6 +636,8 @@ function requeueFailedCreds() {
 requeueOrganization() {
   _corpNum=${1}
   _podName=${2}
+  _systemTypeCd=${3:-BC_REG}
+
   if [ -z "${_corpNum}" ] || [ -z "${_podName}" ]; then
     echo -e \\n"requeueOrganization; Missing parameter!"\\n
     exit 1
@@ -644,17 +646,17 @@ requeueOrganization() {
   # Remove affected credential_log records
   runInContainer -v \
     ${_podName}${resourceSuffix} \
-    "psql -d "'${POSTGRESQL_DATABASE}'" -ac \"delete from credential_log where corp_num in ('${_corpNum}');\""
+    "psql -d "'${POSTGRESQL_DATABASE}'" -ac \"delete from credential_log where corp_num in ('${_corpNum}') AND system_type_cd='${_systemTypeCd}';\""
 
   # Remove affected corp_history_log records
   runInContainer -v \
     ${_podName}${resourceSuffix} \
-    "psql -d "'${POSTGRESQL_DATABASE}'" -ac \"delete from corp_history_log where corp_num in ('${_corpNum}');\""
+    "psql -d "'${POSTGRESQL_DATABASE}'" -ac \"delete from corp_history_log where corp_num in ('${_corpNum}') AND system_type_cd='${_systemTypeCd}';\""
 
   # Requeue affected event_by_corp_filing records
   runInContainer -v \
     ${_podName}${resourceSuffix} \
-    "psql -d "'${POSTGRESQL_DATABASE}'" -ac \"update event_by_corp_filing set process_success = null, process_date = null, process_msg = null where corp_num in ('${_corpNum}');\""
+    "psql -d "'${POSTGRESQL_DATABASE}'" -ac \"update event_by_corp_filing set process_success = null, process_date = null, process_msg = null where corp_num in ('${_corpNum}') AND system_type_cd='${_systemTypeCd}';\""
 }
 
 queueOrganization() {
@@ -1129,7 +1131,7 @@ case "${_cmd}" in
   requeueorganization)
     corpNum=${1}
     dbPodName=${2:-event-db}
-    requeueOrganization "${corpNum}" "${dbPodName}"
+    requeueOrganization "${corpNum}" "${dbPodName}" "BC_REG"
     ;;
   queueorganization)
     corpNum=${1}
@@ -1145,7 +1147,7 @@ case "${_cmd}" in
   requeueorganizationlear)
     corpNum=${1}
     dbPodName=${2:-event-db}
-    requeueOrganization "${corpNum}" "${dbPodName}"
+    requeueOrganization "${corpNum}" "${dbPodName}" "BCREG_LEAR"
     ;;
   queueorganizationlear)
     corpNum=${1}


### PR DESCRIPTION
- Under normal conditions this will not happen since corp numbers are unique.
- This is a special case for FM0073945 which is an active LP in COLIN and an inactive (dissolved) SP in LEAR.